### PR TITLE
Patch: Improve UX - Make self course-level the default option in form

### DIFF
--- a/src/resource/routes.py
+++ b/src/resource/routes.py
@@ -58,7 +58,7 @@ def get_course(identifier):
     course_docs = course.course_docs.all()
     is_empty = False if bool(len(course_docs)) else True
 
-    form = UpdateCourseForm(obj=course)
+    form = UpdateCourseForm(obj=course, data={'levels': course.course_level.name.name})
     form.set_model_instance(course)
 
     context = {

--- a/src/templates/home/level_page.html
+++ b/src/templates/home/level_page.html
@@ -26,9 +26,9 @@
                 <th scope="col"></th>
                 <th scope="col">
                     {% if current_user.is_authenticated %}
-                    <button class="btn btn-secondary float-end" data-bs-toggle="modal" data-bs-target="#add-course-modal">
+                    <button class="btn btn-secondary float-end" title="Add new course" data-bs-toggle="modal" data-bs-target="#add-course-modal">
                     {% else %}
-                    <button class="btn btn-secondary float-end" data-bs-toggle="modal" data-bs-target="#cond-auth-modal">
+                    <button class="btn btn-secondary float-end" title="Add new course" data-bs-toggle="modal" data-bs-target="#cond-auth-modal">
                     {% endif %}
                         <i class="fa-solid fa-folder-plus"></i>
                     </button>


### PR DESCRIPTION
The edit course form now has the level of the current course set by default. Instead of '100'
Former behaviour:
![default-level-selected0](https://github.com/israel-oye/CiStash/assets/97196057/3e64496f-56cb-4721-afa3-133fe13f5bb5)

Current behaviour:
![default-level-selected](https://github.com/israel-oye/CiStash/assets/97196057/731b6752-1e89-4f26-abd9-8295a02721f6)
